### PR TITLE
Added support for Published Collection to metadata placeholder

### DIFF
--- a/PhotoStation_upload.lrplugin/PSLrUtilities.lua
+++ b/PhotoStation_upload.lrplugin/PSLrUtilities.lua
@@ -268,7 +268,7 @@ end
 --	- unrecognized placeholders will be left unchanged, they might be intended path components
 --	- undefined mandatory metadata will be substituted by ?
 --	- undefined optional metadata will be substituted by their default or '' if no default
-function PSLrUtilities.evaluatePathOrFilename(path, srcPhoto, type)
+function PSLrUtilities.evaluatePathOrFilename(path, srcPhoto, type, publishedCollection)
 
 	writeLogfile(3, string.format("evaluatePathOrFilename(path '%s', type '%s' \n", ifnil(path, '<Nil>'), type)) 
 
@@ -402,6 +402,61 @@ function PSLrUtilities.evaluatePathOrFilename(path, srcPhoto, type)
     			return pathLevelExtracted
     		end);
 	end
+
+	local substituteCollectionNameOrPath = function(collectionPath, category)
+		return function(contCollParam)
+			local dataTypeAndPattern, dataDefault = string.match(contCollParam, string.format('{%s:(.*)|(.*)}', category))
+			if not dataTypeAndPattern then
+				dataTypeAndPattern = string.match(contCollParam, string.format('{%s:(.*)}',category))
+			end
+			local dataType, dataPattern = string.match(dataTypeAndPattern, '(%w+)%s+(.*)')
+			if not dataType then
+				dataType = dataTypeAndPattern
+			end
+
+			writeLogfile(4, string.format("evaluatePathOrFilename: '%s': type='%s' pattern='%s'\n", ifnil(contCollParam, '<Nil>'), ifnil(dataType, '<Nil>'), ifnil(dataPattern, '<Nil>'))) 
+			
+			if not dataType or not string.find('name,path', dataType, 1, true) then 
+				writeLogfile(3, string.format("evaluatePathOrFilename:  '%s': type='%s' not valid  --> '%s' \n", ifnil(contCollParam, '<Nil>'), ifnil(dataType, '<Nil>'), contCollParam)) 
+				return contCollParam 
+			end
+			
+			if not collectionPath or not collectionPath[1] then
+				writeLogfile(4, string.format("evaluatePathOrFilename:  '%s': no collections  --> '' \n", ifnil(contCollParam, '<Nil>'))) 
+				return ifnil(dataDefault,'')  
+			end
+			
+			for i = 1, #collectionPath do
+				local dataString
+				
+				if dataType == 'name' then
+					local parents, leaf = string.match(collectionPath[i], "(.*)/([^\/]+)")
+					if not parents then leaf = collectionPath[i] end
+					dataString = leaf
+				else
+					dataString = collectionPath[i]
+				end
+			
+				local dataStringExtracted = dataString
+				if dataString == '' then
+					dataStringExtracted = ifnil(dataDefault, '')
+				else
+					if dataPattern then
+						dataStringExtracted = string.match(dataString, dataPattern)
+					end
+					if not dataStringExtracted then 
+						dataStringExtracted = ifnil(dataDefault, '')
+					else
+						dataStringExtracted = dataStringExtracted
+					end 
+				end
+				writeLogfile(3, string.format("evaluatePathOrFilename: %s  --> %s \n", ifnil(contCollParam, '<Nil>'), ifnil(dataStringExtracted, ''))) 
+				return dataStringExtracted
+			end
+			writeLogfile(3, string.format("evaluatePathOrFilename:  %s: no match  --> '' \n", ifnil(contCollParam, '<Nil>'))) 
+			return ifnil(dataDefault,'')  
+		end
+	end
 	
 	-- get contained collections, if required
 	if string.find(path, "{LrCC:", 1, true) then
@@ -413,58 +468,15 @@ function PSLrUtilities.evaluatePathOrFilename(path, srcPhoto, type)
 		end
 		
 		-- substitute Lr contained collection name or path: {LrCC:<name>|<path> <filter>}
-		path = string.gsub (path, '({LrCC:[^}]*})', function(contCollParam)
-				local dataTypeAndPattern, dataDefault = string.match(contCollParam, '{LrCC:(.*)|(.*)}')
-				if not dataTypeAndPattern then
-					dataTypeAndPattern = string.match(contCollParam, '{LrCC:(.*)}')
-				end
-				local dataType, dataPattern = string.match(dataTypeAndPattern, '(%w+)%s+(.*)')
-				if not dataType then
-					dataType = dataTypeAndPattern
-				end
+		path = string.gsub (path, '({LrCC:[^}]*})', substituteCollectionNameOrPath(containedCollectionPath, 'LrCC'));
+	end
 
- 				writeLogfile(4, string.format("evaluatePathOrFilename: '%s': type='%s' pattern='%s'\n", ifnil(contCollParam, '<Nil>'), ifnil(dataType, '<Nil>'), ifnil(dataPattern, '<Nil>'))) 
-				
-				if not dataType or not string.find('name,path', dataType, 1, true) then 
-					writeLogfile(3, string.format("evaluatePathOrFilename:  '%s': type='%s' not valid  --> '%s' \n", ifnil(contCollParam, '<Nil>'), ifnil(dataType, '<Nil>'), contCollParam)) 
-					return contCollParam 
-				end
-				
-				if not containedCollectionPath or not containedCollectionPath[1] then
-					writeLogfile(4, string.format("evaluatePathOrFilename:  '%s': no collections  --> '' \n", ifnil(contCollParam, '<Nil>'))) 
-					return ifnil(dataDefault,'')  
-				end
-				
-				for i = 1, #containedCollectionPath do
-					local dataString
-					
-					if dataType == 'name' then
-						local parents, leaf = string.match(containedCollectionPath[i], "(.*)/([^\/]+)")
-						if not parents then leaf = containedCollectionPath[i] end
-						dataString = leaf
-					else
-						dataString = containedCollectionPath[i]
-					end
-				
-	    			local dataStringExtracted = dataString
-	    			if dataString == '' then
-    					dataStringExtracted = ifnil(dataDefault, '')
-    				else
-    	    			if dataPattern then
-    	    				dataStringExtracted = string.match(dataString, dataPattern)
-    	    			end
-      					if not dataStringExtracted then 
-      						dataStringExtracted = ifnil(dataDefault, '')
-        				else
-        					dataStringExtracted = dataStringExtracted
-        				end 
-        			end
-					writeLogfile(3, string.format("evaluatePathOrFilename: %s  --> %s \n", ifnil(contCollParam, '<Nil>'), ifnil(dataStringExtracted, ''))) 
-        			return dataStringExtracted
-				end
-				writeLogfile(3, string.format("evaluatePathOrFilename:  %s: no match  --> '' \n", ifnil(contCollParam, '<Nil>'))) 
-				return ifnil(dataDefault,'')  
-			end);
+	-- get published collections, if required
+	if string.find(path, "{LrPC:", 1, true) then
+		local publishedCollectionPath = {PSLrUtilities.getCollectionPath(publishedCollection)}
+		
+		-- substitute Lr published collection name or path: {LrPC:<name>|<path> <filter>}
+		path = string.gsub (path, '({LrPC:[^}]*})', substituteCollectionNameOrPath(publishedCollectionPath, 'LrPC'));
 	end
 	
 	if 	type == 'filename'	then

--- a/PhotoStation_upload.lrplugin/PSUploadTask.lua
+++ b/PhotoStation_upload.lrplugin/PSUploadTask.lua
@@ -693,7 +693,7 @@ local function checkMoved(publishedCollection, exportContext, exportParams)
 		local srcPath = srcPhoto:getRawMetadata('path')
 		local publishedPath = ifnil(pubPhoto:getRemoteId(), '<Nil>')
 		local edited = pubPhoto:getEditedFlag()
-		local dstRoot = PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path')
+		local dstRoot = PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path', publishedCollection)
 
 		progressScope:setCaption(LrPathUtils.leafName(srcPath))
 
@@ -803,12 +803,12 @@ local function movePhotos(publishedCollection, exportContext, exportParams)
 				skipPhoto = true
 			else
     			-- evaluate and sanitize dstRoot: 
-    			dstRoot = PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path')
+    			dstRoot = PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path', publishedCollection)
 
     			-- file renaming: 
     			--	if not Photo StatLr renaming then use srcFilename
     			if exportParams.renameDstFile then
-    				dstFilename = PSLrUtilities.evaluatePathOrFilename(exportParams.dstFilename, srcPhoto, 'filename')
+    				dstFilename = PSLrUtilities.evaluatePathOrFilename(exportParams.dstFilename, srcPhoto, 'filename', publishedCollection)
     			else
     				dstFilename = srcFilename
     			end
@@ -1084,14 +1084,14 @@ function PSUploadTask.processRenderedPhotos( functionContext, exportContext )
 			-- evaluate and sanitize dstRoot: 
 			--   substitute metadata tokens
 			--   replace \ by /, remove leading and trailings slashes
-			dstRoot = 		PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path')
+			dstRoot = 		PSLrUtilities.evaluatePathOrFilename(exportParams.dstRoot, srcPhoto, 'path', publishedCollection)
 
 			-- file renaming: 
 			--	if not Photo StatLr renaming
 			--		if Export: 	use renderedFilename (Lr renaming options may have been turned on)
 			--		else:		use srcFilename
 			if exportParams.renameDstFile then
-				dstFilename = PSLrUtilities.evaluatePathOrFilename(exportParams.dstFilename, srcPhoto, 'filename')
+				dstFilename = PSLrUtilities.evaluatePathOrFilename(exportParams.dstFilename, srcPhoto, 'filename', publishedCollection)
 			else
 				dstFilename = iif(publishMode == 'Export', 	renderedFilename, srcFilename)
 			end


### PR DESCRIPTION
It introduces new category: {LrPC: <name>|<path> <filter>}

Which takes the current Published Collection in similar way as the LrCC works. The code is actually the same, so the only difference is that LrPC will actually be deterministic as there will always be only one Published Collection.

