### PR TITLE
Catch missing Rotation parameter

### DIFF
--- a/PhotoStation_upload.lrplugin/PSExiftoolAPI.lua
+++ b/PhotoStation_upload.lrplugin/PSExiftoolAPI.lua
@@ -337,7 +337,10 @@ function PSExiftoolAPI.queryLrFaceRegionList(h, photoFilename)
     				personTag.height 	= height / (photoDimension.cropBottom - photoDimension.cropTop)
     				personTag.rotation 	= photoRotation
     				personTag.trotation = region.Rotation
-    				personTag.name 		= region.Name
+					personTag.name 		= region.Name
+					
+					if personTag.trotation == nil then personTag.trotation = 0 end
+					if personTag.rotation == nil  then personTag.rotation = 0  end
     				
     				personTags[j] = personTag 
     				


### PR DESCRIPTION
I had multiple issues where exporting of my pictures failed. Debugged showed that either personTag.rotation or personTag.trotation where nil.

I added a check and set them to zero in case of nil.