### PR TITLE
added OTP support

### DIFF
--- a/PhotoStation_upload.lrplugin/PSConvert.lua
+++ b/PhotoStation_upload.lrplugin/PSConvert.lua
@@ -182,12 +182,12 @@ PSConvert_mt = { __index = PSConvert }
 
 PSConvert.downloadUrlIMConvert			= 'https://imagemagick.org/script/download.php'
 PSConvert.defaultInstallPathIMConvert 	= iif(WIN_ENV,
-    										'C:/Program Files/ImageMagick-7.1.0-Q16-HDRI/convert.exe',
+    										'C:/Program Files/ImageMagick-7.1.0-Q16-HDRI/magick.exe',
     										'/usr/local/bin/convert')
 
 PSConvert.downloadUrlDcraw				= 'http://www.dechifro.org/dcraw/'
 PSConvert.defaultInstallPathDcraw 		= iif(WIN_ENV,
-    										'C:/Program Files/ImageMagick-7.1.0-Q16-HDRI/convert.exe/dcraw.exe',
+    										'C:/Program Files/ImageMagick-7.1.0-Q16-HDRI/dcraw.exe',
     										'/usr/local/bin/dcraw')
 
 PSConvert.downloadUrlFfmpeg				= 'https://ffmpeg.org/download.html'

--- a/PhotoStation_upload.lrplugin/PSDialogs.lua
+++ b/PhotoStation_upload.lrplugin/PSDialogs.lua
@@ -1211,6 +1211,13 @@ function PSDialogs.targetPhotoStationView(f, propertyTable)
 					fill_horizontal = 1,
 					value 			= bind 'password',
 				},
+
+				f:checkbox {
+					title 			= LOC "$$$/PSUpload/ExportDialog/UseOtp=Use Otp",
+					tooltip 		= LOC "$$$/PSUpload/ExportDialog/UseOtpTT=Use Otp:\nSelect only, if your user has OTP activated.",
+					fill_horizontal = 1,
+					value 			= bind 'useOtp',
+				},
 			},
 
 			f:separator { fill_horizontal = 1 },

--- a/PhotoStation_upload.lrplugin/PSExportServiceProvider.lua
+++ b/PhotoStation_upload.lrplugin/PSExportServiceProvider.lua
@@ -77,6 +77,8 @@ exportServiceProvider.exportPresetFields = {
 		{ key = 'personalPSOwner', 	default = '' },		-- owner of the Personal Photo Server to upload to
 		{ key = 'username', 		default = '' },		-- account for Photo Server upload
 		{ key = 'password', 		default = '' },		-- guess what...
+		{ key = 'useOtp', 			default = false },		-- OTP
+		{ key = 'otp', 				default = '' },		-- OTP allways empty
 		{ key = 'psVersion', 		default = 68 },		-- Photo Server version: default PS 6.8
 		{ key = 'uploadTimestamp',	default = 'capture' },-- file timestamp for uploaded photos: 'capture', 'upload' or 'mixed' (photos=upload, videos=capture)
 

--- a/PhotoStation_upload.lrplugin/PSPhotoStationAPI.lua
+++ b/PhotoStation_upload.lrplugin/PSPhotoStationAPI.lua
@@ -325,12 +325,12 @@ end
 -- ########################## session management #######################################################
 ---------------------------------------------------------------------------------------------------------
 -- new: set serverUrl, loginPath and uploadPath
-function PhotoStation.new(serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username, password)
+function PhotoStation.new(serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username, password, otp)
 	local h = {} -- the handle
 	local apiInfo = {}
 	local psPath = iif(usePersonalPS, "/~" .. ifnil(personalPSOwner, "unknown") .. "/photo/", "/photo/")
 
-	writeLogfile(4, string.format("PhotoStation.new(url=%s, personal=%s, persUser=%s, timeout=%d, version=%d, username=%s, password=***)\n",
+	writeLogfile(4, string.format("PhotoStation.new(url=%s, personal=%s, persUser=%s, timeout=%d, version=%d, username=%s, password=***, otp=***)\n",
                                     serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username))
 
 	h.serverUrl 	= serverUrl
@@ -338,6 +338,7 @@ function PhotoStation.new(serverUrl, usePersonalPS, personalPSOwner, serverTimeo
 	h.serverVersion	= version
     h.username	    = username
     h.password	    = password
+    h.otp 			= otp
 
 	h.psAlbumRoot	= psPath .. '#!Albums'
 	h.psWebAPI 		= psPath .. 'webapi/'
@@ -428,7 +429,8 @@ function PhotoStation.login(h)
 					 'version=1&' ..
 --					 'enable_syno_token=true&' ..
 					 'username=' .. urlencode(h.username) .. '&' ..
-					 'password=' .. urlencode(h.password)
+					 'password=' .. urlencode(h.password) .. '&' ..
+					 'otp_code=' .. otp
 
 	local respArray, errorCode = PhotoStation.callSynoAPI (h, 'SYNO.PhotoStation.Auth', formData)
 

--- a/PhotoStation_upload.lrplugin/PSPhotosAPI.lua
+++ b/PhotoStation_upload.lrplugin/PSPhotosAPI.lua
@@ -938,18 +938,19 @@ end
 
 ---------------------------------------------------------------------------------------------------------
 -- Photos.new: initialize a Photos API object
-function Photos.new(serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username, password)
+function Photos.new(serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username, password, otp)
 	local h = {} -- the handle
 	local apiInfo = {}
 
-	writeLogfile(4, string.format("Photos.new(url=%s, personal=%s, persUser=%s, timeout=%d, version=%d, username=%s, password=***)\n", 
-                                    serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username))
+	writeLogfile(4, string.format("Photos.new(url=%s, personal=%s, persUser=%s, timeout=%d, version=%d, username=%s, otp=%s, password=***)\n", 
+                                    serverUrl, usePersonalPS, personalPSOwner, serverTimeout, version, username, otp))
 
 	h.serverUrl 	= serverUrl
 	h.serverTimeout = serverTimeout
 	h.serverVersion	= version
     h.username	    = username
     h.password	    = password
+    h.otp 			= otp
 
 	if usePersonalPS then
 		h.userid 		= personalPSOwner
@@ -1004,6 +1005,7 @@ function Photos.login(h)
 		session 			= "webui",
 		account				= urlencode(h.username),
 		passwd				= urlencode(h.password),
+		otp_code			= h.otp,
 --		logintype			= "local",
 		hhid 				= h.hhid,
 		enable_syno_token 	= "yes",


### PR DESCRIPTION
Maintainance:
- Changed standard path, because convert.exe is depricaded. magick.exe is the successor.

Feature request:
- added OTP support

Bugfix:
- changed position of missing settings dialog before server object creatation, so that the asked values will be used